### PR TITLE
Don't send dispatch nor future visits events when machines are ok

### DIFF
--- a/src/main/java/com/redhat/demo/optaplanner/Machine.java
+++ b/src/main/java/com/redhat/demo/optaplanner/Machine.java
@@ -80,6 +80,10 @@ public class Machine {
         this.health = health;
     }
 
+    public boolean isDamaged() {
+        return health < 1.0;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {


### PR DESCRIPTION
Option A) don't send mechanics anywhere. The fix is far from perfect - see the topic on gchat.

Alternative solution is to send mechanics to gate:
https://github.com/rhdemo/2019-demo4-optaplanner/pull/57
(but the issue with all mechanics moving for a while anyway persists)