### PR TITLE
Push a docker image to Quay in the release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,25 +142,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-plugin</artifactId>
-        <version>${version.fabric8.maven.plugin}</version>
-        <configuration>
-          <mode>kubernetes</mode>
-          <pushRegistry>quay.io/redhatdemo</pushRegistry>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>build</goal>
-              <goal>resource</goal>
-              <goal>push</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
@@ -241,6 +222,28 @@
       <properties>
         <spring.profiles.active>prod</spring.profiles.active>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>fabric8-maven-plugin</artifactId>
+            <version>${version.fabric8.maven.plugin}</version>
+            <configuration>
+              <mode>kubernetes</mode>
+              <pushRegistry>quay.io/redhatdemo</pushRegistry>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>build</goal>
+                  <goal>resource</goal>
+                  <goal>push</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 


### PR DESCRIPTION
The issue was that with the <pushRegistry>quay.io/redhatdemo</pushRegistry> being part of the default build, it was no longer possible to deploy to OC4 directly using the fabric8.