### PR TITLE
Hard code generated image name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,13 @@
             <configuration>
               <mode>kubernetes</mode>
               <pushRegistry>quay.io/redhatdemo</pushRegistry>
+              <generator>
+                <config>
+                  <spring-boot>
+                    <name>${project.artifactId}</name>
+                  </spring-boot>
+                </config>
+              </generator>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
When machine isn't connected to an Openshift/Kubernetes server fabric8-maven-plugin fails to automatically detect build mode and it builds an image with default name %g/%a (e.g. optaplanner/optaplanner-demo) which is invalid because quay.io registry doesn't allow nested repositories.
To reproduce run `oc cluster down` before running `mvn clean install -Prelease`. You should see `[WARNING] F8: Cannot access cluster for detecting mode: Failed to connect to /127.0.0.1:8443` in the logs.