### PR TITLE
Avoid calling resetMachineHealth() 15 times per dispatchMechanic() call

### DIFF
--- a/src/main/java/com/redhat/demo/optaplanner/GameServiceImpl.java
+++ b/src/main/java/com/redhat/demo/optaplanner/GameServiceImpl.java
@@ -170,11 +170,13 @@ public class GameServiceImpl implements GameService {
             // Check mechanic fixed or departure events
             for (int i = 0; i < mechanics.size(); i++) {
                 Mechanic mechanic = mechanics.get(i);
-                if (timeMillis >= mechanic.getFocusDepartureTimeMillis() - appConfiguration.getThumbUpDurationMillis()) {
+                if (timeMillis >= mechanic.getFocusDepartureTimeMillis() - appConfiguration.getThumbUpDurationMillis()
+                        && !mechanic.isFocusFixed()) {
                     int focusMachineIndex = mechanic.getFocusMachineIndex();
                     if (focusMachineIndex != appConfiguration.getGateMachineIndex()) {
                         upstreamConnector.resetMachineHealth(focusMachineIndex);
                     }
+                    mechanic.setFocusFixed(true);
                 }
                 if (timeMillis >= mechanic.getFocusDepartureTimeMillis()) {
                     if (isAnyFutureMachineDamaged(mechanic)) {
@@ -182,6 +184,7 @@ public class GameServiceImpl implements GameService {
                     } else {
                         dispatchMechanicToGate(mechanic);
                     }
+                    mechanic.setFocusFixed(false);
                 }
             }
         }

--- a/src/main/java/com/redhat/demo/optaplanner/Mechanic.java
+++ b/src/main/java/com/redhat/demo/optaplanner/Mechanic.java
@@ -9,6 +9,7 @@ public class Mechanic {
     private int originalMachineIndex;
     private int focusMachineIndex;
     private long focusTravelTimeMillis;
+    private boolean focusFixed; // True if in thumbs up duration
 
     private int[] futureMachineIndexes;
 
@@ -26,6 +27,7 @@ public class Mechanic {
         this.originalMachineIndex = originalMachineIndex;
         this.focusMachineIndex = focusMachineIndex;
         this.focusTravelTimeMillis = focusTravelTimeMillis;
+        this.focusFixed = false;
         this.futureMachineIndexes = new int[0];
     }
 
@@ -67,6 +69,14 @@ public class Mechanic {
 
     public void setFocusTravelTimeMillis(long focusTravelTimeMillis) {
         this.focusTravelTimeMillis = focusTravelTimeMillis;
+    }
+
+    public boolean isFocusFixed() {
+        return focusFixed;
+    }
+
+    public void setFocusFixed(boolean focusFixed) {
+        this.focusFixed = focusFixed;
     }
 
     public int[] getFutureMachineIndexes() {


### PR DESCRIPTION
Before this change, adding System.out's in
  `if (timeMillis >= mechanic.getFocusDepartureTimeMillis() - appConfiguration.getThumbUpDurationMillis())`
happen a dozen+ times more than those in
  `if (timeMillis >= mechanic.getFocusDepartureTimeMillis())`