### PR TITLE
Reduce thumb up duration

### DIFF
--- a/src/main/java/com/redhat/demo/optaplanner/config/AppConfiguration.java
+++ b/src/main/java/com/redhat/demo/optaplanner/config/AppConfiguration.java
@@ -35,8 +35,8 @@ public class AppConfiguration {
     private int machinesAndGateLength;
     private int initialMechanicsSize = 0;
     private double mechanicSpeed = 0.15;
-    private long fixDurationMillis = 2200L;
-    private long thumbUpDurationMillis = 500L;
+    private long fixDurationMillis = 2400L;
+    private long thumbUpDurationMillis = 80L;
 
     private int[] machineIndexToGridX;
     private int[] machineIndexToGridY;


### PR DESCRIPTION
Reduce thumb up duration because the fix health spam showed a short thumb up isn't noticeable
Slightly increase fixDuration so the mechs stay stationary long enough.

Side effect from https://github.com/rhdemo/2019-demo4-optaplanner/pull/81