### PR TITLE
Avoid exception in tick thread when resetting the game

### DIFF
--- a/src/main/java/com/redhat/demo/optaplanner/GameServiceImpl.java
+++ b/src/main/java/com/redhat/demo/optaplanner/GameServiceImpl.java
@@ -157,7 +157,7 @@ public class GameServiceImpl implements GameService {
     }
 
     @Scheduled(fixedDelay = AppConfiguration.TIME_TICK_MILLIS)
-    public void tick() {
+    public synchronized void tick() {
         timeMillis += AppConfiguration.TIME_TICK_MILLIS;
 
         updateMachineHealth();


### PR DESCRIPTION
A fix to https://github.com/rhdemo/2019-demo4-optaplanner/issues/85 and https://github.com/rhdemo/2019-demo4-optaplanner/issues/67

The issue was race condition - `tick()` happened when the game was being restarted and some data structures not re-initialized yet, resulting most often in NPE.

The solution is to make both the `reset()` and `tick()` synchronized - as both methods belong to the same object, they share a monitor and thus only one of them can be executed at any point in time.