### PR TITLE
Get OptaPlannerConfig when connecting UI

### DIFF
--- a/src/main/java/com/redhat/demo/optaplanner/GameService.java
+++ b/src/main/java/com/redhat/demo/optaplanner/GameService.java
@@ -12,4 +12,6 @@ public interface GameService {
      void initializeDownstream();
 
      void reset();
+
+     boolean isDispatchPaused();
 }

--- a/src/main/java/com/redhat/demo/optaplanner/GameServiceImpl.java
+++ b/src/main/java/com/redhat/demo/optaplanner/GameServiceImpl.java
@@ -150,6 +150,11 @@ public class GameServiceImpl implements GameService {
         initializeDownstream();
     }
 
+    @Override
+    public boolean isDispatchPaused() {
+        return dispatchPaused;
+    }
+
     private void healAllMachines() {
         for (int i = 0; i < appConfiguration.getMachinesOnlyLength(); i++) {
             upstreamConnector.resetMachineHealth(machines[i].getMachineIndex());

--- a/src/main/java/com/redhat/demo/optaplanner/simulation/SimulationService.java
+++ b/src/main/java/com/redhat/demo/optaplanner/simulation/SimulationService.java
@@ -82,6 +82,10 @@ public class SimulationService {
         upstreamConnector.setSimulationStatus(simulating);
     }
 
+    public boolean isSimulating() {
+        return simulating;
+    }
+
     public void damageMachine(int machineIndex, double amount) {
         upstreamConnector.damageMachine(machineIndex, amount);
     }

--- a/src/main/java/com/redhat/demo/optaplanner/websocket/response/ConnectResponse.java
+++ b/src/main/java/com/redhat/demo/optaplanner/websocket/response/ConnectResponse.java
@@ -1,5 +1,6 @@
 package com.redhat.demo.optaplanner.websocket.response;
 
+import com.redhat.demo.optaplanner.upstream.utils.OptaPlannerConfig;
 import com.redhat.demo.optaplanner.websocket.domain.JsonLocation;
 import com.redhat.demo.optaplanner.websocket.domain.JsonMechanic;
 
@@ -7,11 +8,13 @@ public class ConnectResponse extends AbstractResponse {
 
     private JsonLocation[] locations;
     private JsonMechanic[] mechanics;
+    private OptaPlannerConfig optaPlannerConfig;
 
-    public ConnectResponse(JsonLocation[] locations, JsonMechanic[] mechanics) {
+    public ConnectResponse(JsonLocation[] locations, JsonMechanic[] mechanics, OptaPlannerConfig optaPlannerConfig) {
         super(ResponseType.CONNECT);
         this.locations = locations;
         this.mechanics = mechanics;
+        this.optaPlannerConfig = optaPlannerConfig;
     }
 
     public JsonLocation[] getLocations() {
@@ -20,5 +23,9 @@ public class ConnectResponse extends AbstractResponse {
 
     public JsonMechanic[] getMechanics() {
         return mechanics;
+    }
+
+    public OptaPlannerConfig getOptaPlannerConfig() {
+        return optaPlannerConfig;
     }
 }

--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -346,6 +346,8 @@ function processResponse(response) {
         console.log("Connected to a server");
         locations = response.locations;
         mechanics = response.mechanics;
+        showPauzed(!response.optaPlannerConfig.dispatchActive);
+        showSimulation(response.optaPlannerConfig.simulationActive);
         $( "#benchmarkMechanicDetails" ).text("fixed by " + mechanics.length + " mechanics");
     } else if (response.responseType === ResponseType.ADD_MECHANIC) {
         mechanics.push(response.mechanic);


### PR DESCRIPTION
In temp UI, dispatch and simulation buttons always start with default (dispatch: paused, simulation: paused) when refreshing browser page even if the true state is different.
- Open temp UI
- Click `unpauze` and `start` simulation.
- Refresh browser: although both dispatch and simulation are active, the buttons don't reflect that state.